### PR TITLE
Add AI prompt sender extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,29 @@
-# promptmate README
+# PromptMate
 
-This is the README for your extension "promptmate". After writing up a brief description, we recommend including the following sections.
+PromptMate is a simple VS Code extension for sending prompts to an AI service from within the editor. It provides a command to send a prompt and a settings panel where you can configure the API details.
 
 ## Features
 
-Describe specific features of your extension including screenshots of your extension in action. Image paths are relative to this README file.
+- **Send Prompt to AI** command available from the Command Palette.
+- **AI Settings** view under the Extensions sidebar to configure the API provider, key and context file.
+- Responses from the AI are displayed directly in the extension panel.
 
-For example if there is an image subfolder under your extension project workspace:
+## Setup
 
-\!\[feature X\]\(images/feature-x.png\)
+1. Run `npm install` to install dependencies.
+2. Press `F5` in VS Code to launch an Extension Development Host.
 
-> Tip: Many popular extensions utilize animations. This is an excellent way to show off your extension! We recommend short, focused animations that are easy to follow.
+## Obtaining an API Key
 
-## Requirements
+PromptMate expects an HTTP endpoint that accepts a JSON payload with a `prompt` field. Many AI providers expose such APIs. For example, you can create an API key on [OpenAI](https://platform.openai.com/) and set the provider to their completion endpoint.
 
-If you have any requirements or dependencies, add a section describing those and how to install and configure them.
+## Usage
 
-## Extension Settings
+1. Open the **AI Settings** view from the Extensions side bar and fill in:
+   - **API Provider**: URL of the endpoint.
+   - **API Key**: your authentication key.
+   - **Context File Path**: absolute path to a file whose contents should be prepended to your prompt.
+2. Run **Send Prompt to AI** from the Command Palette.
+3. Enter your prompt and press **Send** to see the AI's response.
 
-Include if your extension adds any VS Code settings through the `contributes.configuration` extension point.
-
-For example:
-
-This extension contributes the following settings:
-
-* `myExtension.enable`: Enable/disable this extension.
-* `myExtension.thing`: Set to `blah` to do something.
-
-## Known Issues
-
-Calling out known issues can help limit users opening duplicate issues against your extension.
-
-## Release Notes
-
-Users appreciate release notes as you update your extension.
-
-### 1.0.0
-
-Initial release of ...
-
-### 1.0.1
-
-Fixed issue #.
-
-### 1.1.0
-
-Added features X, Y, and Z.
-
----
-
-## Following extension guidelines
-
-Ensure that you've read through the extensions guidelines and follow the best practices for creating your extension.
-
-* [Extension Guidelines](https://code.visualstudio.com/api/references/extension-guidelines)
-
-## Working with Markdown
-
-You can author your README using Visual Studio Code. Here are some useful editor keyboard shortcuts:
-
-* Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux).
-* Toggle preview (`Shift+Cmd+V` on macOS or `Shift+Ctrl+V` on Windows and Linux).
-* Press `Ctrl+Space` (Windows, Linux, macOS) to see a list of Markdown snippets.
-
-## For more information
-
-* [Visual Studio Code's Markdown Support](http://code.visualstudio.com/docs/languages/markdown)
-* [Markdown Syntax Reference](https://help.github.com/articles/markdown-basics/)
-
-**Enjoy!**
+All errors are shown inside the panel.

--- a/package.json
+++ b/package.json
@@ -9,15 +9,51 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onCommand:promptmate.sendPrompt",
+    "onCommand:promptmate.openSettings",
+    "onView:promptmate.settingsView"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
       {
-        "command": "promptmate.helloWorld",
-        "title": "Hello World"
+        "command": "promptmate.sendPrompt",
+        "title": "Send Prompt to AI"
+      },
+      {
+        "command": "promptmate.openSettings",
+        "title": "AI Settings"
       }
-    ]
+    ],
+    "views": {
+      "workbench.view.extensions": [
+        {
+          "id": "promptmate.settingsView",
+          "name": "AI Settings"
+        }
+      ]
+    },
+    "configuration": {
+      "title": "AI Prompt Sender",
+      "properties": {
+        "aiPromptSender.apiProvider": {
+          "type": "string",
+          "default": "",
+          "description": "URL of the AI API provider"
+        },
+        "aiPromptSender.apiKey": {
+          "type": "string",
+          "default": "",
+          "description": "API key for authentication"
+        },
+        "aiPromptSender.contextFilePath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to context file"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,25 @@
+export async function sendPrompt(apiProvider: string, apiKey: string, payload: unknown): Promise<string> {
+    const response = await fetch(apiProvider, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+        throw new Error(`Request failed: ${response.status} ${response.statusText}`);
+    }
+
+    const data: any = await response.json();
+    if (typeof data === 'string') {
+        return data;
+    }
+
+    if (data.response) {
+        return typeof data.response === 'string' ? data.response : JSON.stringify(data.response);
+    }
+
+    return JSON.stringify(data);
+}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,10 @@
+import * as vscode from 'vscode';
+import { MainPanel } from './webviews/mainPanel';
+import { SettingsPanel } from './webviews/settingsPanel';
+
+export function registerCommands(context: vscode.ExtensionContext, main: MainPanel, settings: SettingsPanel) {
+    context.subscriptions.push(
+        vscode.commands.registerCommand('promptmate.sendPrompt', () => main.show()),
+        vscode.commands.registerCommand('promptmate.openSettings', () => settings.show()),
+    );
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,26 +1,17 @@
-// The module 'vscode' contains the VS Code extensibility API
-// Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+import { MainPanel } from './webviews/mainPanel';
+import { SettingsPanel } from './webviews/settingsPanel';
+import { registerCommands } from './commands';
+import { SettingsViewProvider } from './views/settingsView';
 
-// This method is called when your extension is activated
-// Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
+    const mainPanel = new MainPanel(context);
+    const settingsPanel = new SettingsPanel(context);
 
-	// Use the console to output diagnostic information (console.log) and errors (console.error)
-	// This line of code will only be executed once when your extension is activated
-	console.log('Congratulations, your extension "promptmate" is now active!');
+    registerCommands(context, mainPanel, settingsPanel);
 
-	// The command has been defined in the package.json file
-	// Now provide the implementation of the command with registerCommand
-	// The commandId parameter must match the command field in package.json
-	const disposable = vscode.commands.registerCommand('promptmate.helloWorld', () => {
-		// The code you place here will be executed every time your command is executed
-		// Display a message box to the user
-		vscode.window.showInformationMessage('Hello World from promptmate!');
-	});
-
-	context.subscriptions.push(disposable);
+    const settingsView = new SettingsViewProvider(context);
+    vscode.window.registerTreeDataProvider('promptmate.settingsView', settingsView);
 }
 
-// This method is called when your extension is deactivated
 export function deactivate() {}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,23 @@
+import * as vscode from 'vscode';
+
+export interface AISettings {
+    apiProvider: string;
+    apiKey: string;
+    contextFilePath: string;
+}
+
+export function getSettings(): AISettings {
+    const config = vscode.workspace.getConfiguration('aiPromptSender');
+    return {
+        apiProvider: config.get('apiProvider', ''),
+        apiKey: config.get('apiKey', ''),
+        contextFilePath: config.get('contextFilePath', ''),
+    };
+}
+
+export async function updateSettings(settings: AISettings): Promise<void> {
+    const config = vscode.workspace.getConfiguration('aiPromptSender');
+    await config.update('apiProvider', settings.apiProvider, vscode.ConfigurationTarget.Global);
+    await config.update('apiKey', settings.apiKey, vscode.ConfigurationTarget.Global);
+    await config.update('contextFilePath', settings.contextFilePath, vscode.ConfigurationTarget.Global);
+}

--- a/src/views/settingsView.ts
+++ b/src/views/settingsView.ts
@@ -1,0 +1,18 @@
+import * as vscode from 'vscode';
+
+export class SettingsViewProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+    constructor(private readonly context: vscode.ExtensionContext) {}
+
+    getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
+        return element;
+    }
+
+    getChildren(): vscode.ProviderResult<vscode.TreeItem[]> {
+        const item = new vscode.TreeItem('Open AI Settings');
+        item.command = {
+            command: 'promptmate.openSettings',
+            title: 'Open AI Settings',
+        };
+        return [item];
+    }
+}

--- a/src/webviews/mainPanel.ts
+++ b/src/webviews/mainPanel.ts
@@ -1,0 +1,110 @@
+import * as vscode from 'vscode';
+import { getSettings } from '../settings';
+import { sendPrompt } from '../api/client';
+import * as fs from 'fs/promises';
+
+export class MainPanel {
+    public static readonly viewType = 'promptmate.mainPanel';
+    private panel: vscode.WebviewPanel | undefined;
+
+    constructor(private readonly context: vscode.ExtensionContext) {}
+
+    public show() {
+        if (this.panel) {
+            this.panel.reveal();
+            return;
+        }
+
+        this.panel = vscode.window.createWebviewPanel(
+            MainPanel.viewType,
+            'Send Prompt to AI',
+            vscode.ViewColumn.One,
+            { enableScripts: true }
+        );
+
+        this.panel.onDidDispose(() => {
+            this.panel = undefined;
+        });
+
+        this.panel.webview.html = this.getHtml();
+        this.panel.webview.onDidReceiveMessage(async msg => {
+            switch (msg.command) {
+                case 'send':
+                    await this.handleSend(msg.prompt);
+                    break;
+            }
+        });
+    }
+
+    private async handleSend(prompt: string) {
+        if (!this.panel) {
+            return;
+        }
+        const webview = this.panel.webview;
+        try {
+            const settings = getSettings();
+            if (!settings.apiProvider || !settings.apiKey || !settings.contextFilePath) {
+                throw new Error('Please configure API Provider, API Key, and Context File Path.');
+            }
+            const context = await fs.readFile(settings.contextFilePath, 'utf8');
+            const payload = {
+                prompt: `${context}\n${prompt}`,
+            };
+            const response = await sendPrompt(settings.apiProvider, settings.apiKey, payload);
+            webview.postMessage({ command: 'reply', text: response });
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            webview.postMessage({ command: 'error', text: msg });
+        }
+    }
+
+    private getHtml(): string {
+        const nonce = getNonce();
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-${nonce}'; style-src 'nonce-${nonce}';">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Send Prompt to AI</title>
+    <style nonce="${nonce}">
+        body { font-family: sans-serif; margin: 0; padding: 1rem; }
+        textarea { width: 100%; height: 8rem; }
+        #response { margin-top: 1rem; white-space: pre-wrap; border: 1px solid #ccc; padding: 0.5rem; min-height: 4rem; }
+        button { margin-top: 0.5rem; }
+    </style>
+</head>
+<body>
+    <textarea id="prompt" placeholder="Enter your prompt"></textarea>
+    <br/>
+    <button id="send">Send</button>
+    <div id="response"></div>
+    <script nonce="${nonce}">
+        const vscode = acquireVsCodeApi();
+        document.getElementById('send').addEventListener('click', () => {
+            const prompt = (document.getElementById('prompt')).value;
+            vscode.postMessage({ command: 'send', prompt });
+        });
+        window.addEventListener('message', event => {
+            const msg = event.data;
+            if (msg.command === 'reply') {
+                document.getElementById('response').textContent = msg.text;
+            }
+            if (msg.command === 'error') {
+                document.getElementById('response').textContent = 'Error: ' + msg.text;
+            }
+        });
+    </script>
+</body>
+</html>`;
+    }
+}
+
+function getNonce() {
+    let text = '';
+    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    for (let i = 0; i < 32; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
+}

--- a/src/webviews/settingsPanel.ts
+++ b/src/webviews/settingsPanel.ts
@@ -1,0 +1,136 @@
+import * as vscode from 'vscode';
+import { getSettings, updateSettings, AISettings } from '../settings';
+
+export class SettingsPanel {
+    public static readonly viewType = 'promptmate.settingsPanel';
+    private panel: vscode.WebviewPanel | undefined;
+
+    constructor(private readonly context: vscode.ExtensionContext) {}
+
+    public show() {
+        if (this.panel) {
+            this.panel.reveal();
+            return;
+        }
+
+        this.panel = vscode.window.createWebviewPanel(
+            SettingsPanel.viewType,
+            'AI Settings',
+            vscode.ViewColumn.Active,
+            { enableScripts: true }
+        );
+
+        this.panel.onDidDispose(() => {
+            this.panel = undefined;
+        });
+
+        this.panel.webview.html = this.getHtml();
+        this.panel.webview.onDidReceiveMessage(async msg => {
+            switch (msg.command) {
+                case 'save':
+                    await this.handleSave(msg.settings);
+                    break;
+                case 'browse':
+                    await this.handleBrowse();
+                    break;
+            }
+        });
+    }
+
+    private async handleSave(settings: AISettings) {
+        if (!this.panel) {
+            return;
+        }
+        try {
+            if (!settings.apiProvider || !settings.apiKey || !settings.contextFilePath) {
+                throw new Error('All fields are required.');
+            }
+            await updateSettings(settings);
+            this.panel.webview.postMessage({ command: 'saved' });
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            this.panel.webview.postMessage({ command: 'error', text: msg });
+        }
+    }
+
+    private async handleBrowse() {
+        if (!this.panel) {
+            return;
+        }
+        const uri = await vscode.window.showOpenDialog({ canSelectMany: false, openLabel: 'Select context file' });
+        if (uri && uri[0]) {
+            this.panel.webview.postMessage({ command: 'contextPath', path: uri[0].fsPath });
+        }
+    }
+
+    private getHtml(): string {
+        const nonce = getNonce();
+        const settings = getSettings();
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'nonce-${nonce}'; style-src 'nonce-${nonce}';">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AI Settings</title>
+    <style nonce="${nonce}">
+        body { font-family: sans-serif; margin: 0; padding: 1rem; }
+        input[type=text], input[type=password] { width: 100%; }
+        label { display: block; margin-top: 0.5rem; }
+        #message { color: red; margin-top: 0.5rem; }
+        button { margin-top: 1rem; }
+    </style>
+</head>
+<body>
+    <label>API Provider
+        <input id="provider" type="text" value="${settings.apiProvider}" />
+    </label>
+    <label>API Key
+        <input id="key" type="password" value="${settings.apiKey}" />
+    </label>
+    <label>Context File Path
+        <input id="context" type="text" value="${settings.contextFilePath}" />
+        <button id="browse" type="button">Browse...</button>
+    </label>
+    <div id="message"></div>
+    <button id="save">Save</button>
+    <script nonce="${nonce}">
+        const vscode = acquireVsCodeApi();
+        document.getElementById('save').addEventListener('click', () => {
+            const settings = {
+                apiProvider: document.getElementById('provider').value,
+                apiKey: document.getElementById('key').value,
+                contextFilePath: document.getElementById('context').value
+            };
+            vscode.postMessage({ command: 'save', settings });
+        });
+        document.getElementById('browse').addEventListener('click', () => {
+            vscode.postMessage({ command: 'browse' });
+        });
+        window.addEventListener('message', event => {
+            const msg = event.data;
+            if (msg.command === 'error') {
+                document.getElementById('message').textContent = msg.text;
+            }
+            if (msg.command === 'saved') {
+                document.getElementById('message').style.color = 'green';
+                document.getElementById('message').textContent = 'Settings saved';
+            }
+            if (msg.command === 'contextPath') {
+                document.getElementById('context').value = msg.path;
+            }
+        });
+    </script>
+</body>
+</html>`;
+    }
+}
+
+function getNonce() {
+    let text = '';
+    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    for (let i = 0; i < 32; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,13 @@
 		"module": "Node16",
 		"target": "ES2022",
 		"outDir": "out",
-		"lib": [
-			"ES2022"
-		],
-		"sourceMap": true,
-		"rootDir": "src",
-		"strict": true,   /* enable all strict type-checking options */
+        "lib": [
+                        "ES2022"
+        ],
+        "sourceMap": true,
+        "rootDir": "src",
+        "strict": true,   /* enable all strict type-checking options */
+        "types": ["node", "vscode", "mocha"]
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */


### PR DESCRIPTION
## Summary
- implement `Send Prompt to AI` command with a Webview panel
- add `AI Settings` configuration Webview accessible from the Extensions sidebar
- manage extension configuration and API calls
- update project configuration and README

## Testing
- `npm run compile`
- `npm test` *(fails: vscode-test output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_684824d30304832c9b6996ee3a52220b